### PR TITLE
Add Org Syntax Definition (Draft)

### DIFF
--- a/org-syntax.org
+++ b/org-syntax.org
@@ -1,0 +1,918 @@
+# Created 2016-02-25 Thu 13:47
+#+OPTIONS: toc:t ':t author:nil
+#+TITLE: Org Syntax (draft)
+#+LANGUAGE: en
+#+CATEGORY: worg
+#+BIND: sentence-end-double-space t
+
+This document describes and comments Org syntax as it is currently
+read by its parser (Org Elements) and, therefore, by the export
+framework.  It also includes a few comments on that syntax.
+
+A core concept in this syntax is that only headlines, sections,
+planning lines and property drawers are context-free[fn:1][fn:2].
+Every other syntactical part only exists within specific environments.
+
+Three categories are used to classify these environments: "Greater
+elements", "elements", and "objects", from the broadest scope to the
+narrowest.  The word "element" is used for both Greater and non-Greater
+elements, the context should make that clear.
+
+The paragraph is the unit of measurement.  An element defines
+syntactical parts that are at the same level as a paragraph,
+i.e. which cannot contain or be included in a paragraph.  An object is
+a part that could be included in an element.  Greater elements are all
+parts that can contain an element.
+
+Empty lines belong to the largest element ending before them.  For
+example, in a list, empty lines between items belong are part of the
+item before them, but empty lines at the end of a list belong to the
+plain list element.
+
+Unless specified otherwise, case is not significant.
+
+[fn:1] In particular, the parser requires stars at column 0 to be
+quoted by a comma when they do not define a headline.
+
+[fn:2] It also means that only headlines and sections can be
+recognized just by looking at the beginning of the line.  Planning
+lines and property drawers can be recognized by looking at one or two
+lines above.
+
+As a consequence, using ~org-element-at-point~ or
+~org-element-context~ will move up to the parent headline, and parse
+top-down from there until context around original location is found.
+
+* Headlines and Sections
+A headline is defined as:
+
+#+BEGIN_EXAMPLE
+STARS KEYWORD PRIORITY TITLE TAGS
+#+END_EXAMPLE
+
+STARS is a string starting at column 0, containing at least one
+asterisk (and up to ~org-inlinetask-min-level~ if =org-inlinetask=
+library is loaded) and ended by a space character.  The number of
+asterisks is used to define the level of the headline.  It's the
+sole compulsory part of a headline.
+
+KEYWORD is a TODO keyword, which has to belong to the list defined
+in ~org-todo-keywords-1~.  Case is significant.
+
+PRIORITY is a priority cookie, i.e. a single letter preceded by
+a hash sign # and enclosed within square brackets.
+
+TITLE can be made of any character but a new line.  Though, it will
+match after every other part have been matched.
+
+TAGS is made of words containing any alpha-numeric character,
+underscore, at sign, hash sign or percent sign, and separated with
+colons.
+
+Examples of valid headlines include:
+
+#+BEGIN_EXAMPLE
+,*
+
+,** DONE
+
+,*** Some e-mail
+
+,**** TODO [#A] COMMENT Title :tag:a2%:
+#+END_EXAMPLE
+
+If the first word appearing in the title is "COMMENT", the headline
+will be considered as "commented".  Case is significant.
+
+If its title is ~org-footnote-section~, it will be considered as
+a "footnote section".  Case is significant.
+
+If "ARCHIVE" is one of its tags, it will be considered as
+"archived".  Case is significant.
+
+A headline contains directly one section (optionally), followed by
+any number of deeper level headlines.
+
+A section contains directly any greater element or element.  Only
+a headline can contain a section.  As an exception, text before the
+first headline in the document also belongs to a section.
+
+As an example, consider the following document:
+
+#+BEGIN_SRC org
+  An introduction.
+
+  ,* A Headline 
+
+    Some text.
+
+  ,** Sub-Topic 1
+
+  ,** Sub-Topic 2
+
+  ,*** Additional entry 
+#+END_SRC
+
+Its internal structure could be summarized as:
+
+#+BEGIN_EXAMPLE
+(document
+ (section)
+ (headline
+  (section)
+  (headline)
+  (headline
+   (headline))))
+#+END_EXAMPLE
+
+* Affiliated Keywords
+With the exception of [[#Inlinetasks][inlinetasks]], [[#Plain_Lists_and_Items][items]], [[#Clock,_Diary_Sexp_and_Planning][planning]], [[#Clock,_Diary_Sexp_and_Planning][clocks]], [[#Node_Properties][node
+properties]] and [[#Table_Rows][table rows]], every other element type can be assigned
+attributes.
+
+This is done by adding specific keywords, named "affiliated
+keywords", just above the element considered, no blank line
+allowed.
+
+Affiliated keywords are built upon one of the following patterns:
+"#+KEY: VALUE", "#+KEY[OPTIONAL]: VALUE" or "#+ATTR_BACKEND: VALUE".
+
+KEY is either "CAPTION", "HEADER", "NAME", "PLOT" or "RESULTS"
+string.
+
+BACKEND is a string constituted of alpha-numeric characters, hyphens
+or underscores.
+
+OPTIONAL and VALUE can contain any character but a new line.  Only
+"CAPTION" and "RESULTS" keywords can have an optional value.
+
+An affiliated keyword can appear more than once if KEY is either
+"CAPTION" or "HEADER" or if its pattern is "#+ATTR_BACKEND: VALUE".
+
+"CAPTION", "AUTHOR", "DATE" and "TITLE" keywords can contain objects
+in their value and their optional value, if applicable.
+
+* Greater Elements
+Unless specified otherwise, greater elements can contain directly
+any other element or greater element excepted:
+
+- elements of their own type,
+- [[#Node_Properties][node properties]], which can only be found in [[#Property_Drawers][property drawers]],
+- [[#Plain_Lists_and_Items][items]], which can only be found in [[#Plain_Lists_and_Items][plain lists]].
+
+** Greater Blocks
+Greater blocks consist in the following pattern:
+
+#+BEGIN_EXAMPLE
+,#+BEGIN_NAME PARAMETERS
+CONTENTS
+,#+END_NAME
+#+END_EXAMPLE
+
+NAME can contain any non-whitespace character.
+
+PARAMETERS can contain any character other than new line, and can
+be omitted.
+
+If NAME is "CENTER", it will be a "center block".  If it is
+"QUOTE", it will be a "quote block".
+
+If the block is neither a center block, a quote block or a [[#Blocks][block
+element]], it will be a "special block".
+
+CONTENTS can contain any element, except : a line =#+END_NAME= on
+its own.  Also lines beginning with STARS must be quoted by
+a comma.
+
+** Drawers and Property Drawers
+Pattern for drawers is:
+
+#+BEGIN_EXAMPLE
+:NAME:
+CONTENTS
+:END:
+#+END_EXAMPLE
+
+NAME can contain word-constituent characters, hyphens and
+underscores.
+
+CONTENTS can contain any element but another drawer.
+
+** Dynamic Blocks
+Pattern for dynamic blocks is:
+
+#+BEGIN_EXAMPLE
+,#+BEGIN: NAME PARAMETERS
+CONTENTS
+,#+END:
+#+END_EXAMPLE
+
+NAME cannot contain any whitespace character.
+
+PARAMETERS can contain any character and can be omitted.
+
+** Footnote Definitions
+Pattern for footnote definitions is:
+
+#+BEGIN_EXAMPLE
+[fn:LABEL] CONTENTS
+#+END_EXAMPLE
+
+It must start at column 0.
+
+LABEL is either a number or follows the pattern "fn:WORD", where
+word can contain any word-constituent character, hyphens and
+underscore characters.
+
+CONTENTS can contain any element excepted another footnote
+definition.  It ends at the next footnote definition, the next
+headline, two consecutive empty lines or the end of buffer.
+
+** Inlinetasks
+Inlinetasks are defined by ~org-inlinetask-min-level~ contiguous
+asterisk characters starting at column 0, followed by a whitespace
+character.
+
+Optionally, inlinetasks can be ended with a string constituted of
+~org-inlinetask-min-level~ contiguous asterisk characters starting
+at column 0, followed by a space and the "END" string.
+
+Inlinetasks are recognized only after =org-inlinetask= library is
+loaded.
+
+** Plain Lists and Items
+Items are defined by a line starting with the following pattern:
+"BULLET COUNTER-SET CHECK-BOX TAG", in which only BULLET is
+mandatory.
+
+BULLET is either an asterisk, a hyphen, a plus sign character or
+follows either the pattern "COUNTER." or "COUNTER)".  In any case,
+BULLET is follwed by a whitespace character or line ending.
+
+COUNTER can be a number or a single letter.
+
+COUNTER-SET follows the pattern [@COUNTER].
+
+CHECK-BOX is either a single whitespace character, a "X" character
+or a hyphen, enclosed within square brackets.
+
+TAG follows "TAG-TEXT ::" pattern, where TAG-TEXT can contain any
+character but a new line.
+
+An item ends before the next item, the first line less or equally
+indented than its starting line, or two consecutive empty lines.
+Indentation of lines within other greater elements do not count,
+neither do inlinetasks boundaries.
+
+A plain list is a set of consecutive items of the same indentation.
+It can only directly contain items.
+
+If first item in a plain list has a counter in its bullet, the
+plain list will be an "ordered plain-list".  If it contains a tag,
+it will be a "descriptive list".  Otherwise, it will be an
+"unordered list".  List types are mutually exclusive.
+
+For example, consider the following excerpt of an Org document:
+
+#+BEGIN_EXAMPLE
+1. item 1
+2. [X] item 2
+   - some tag :: item 2.1
+#+END_EXAMPLE
+
+Its internal structure is as follows:
+
+#+BEGIN_EXAMPLE
+(ordered-plain-list
+ (item)
+ (item
+  (descriptive-plain-list
+   (item))))
+#+END_EXAMPLE
+
+** Property Drawers
+Property drawers are a special type of drawer containing properties
+attached to a headline.  They are located right after a [[#Headlines_and_Sections][headline]]
+and its [[#Clock,_Diary_Sexp_and_Planning][planning]] information.
+
+#+BEGIN_EXAMPLE
+HEADLINE
+PROPERTYDRAWER
+
+HEADLINE
+PLANNING
+PROPERTYDRAWER
+#+END_EXAMPLE
+
+PROPERTYDRAWER follows the pattern
+
+#+BEGIN_EXAMPLE
+:PROPERTIES:
+CONTENTS
+:END:
+#+END_EXAMPLE
+
+where CONTENTS consists of zero or more [[#Node_Properties][node properties]].
+
+** Tables
+Tables start at lines beginning with either a vertical bar or the
+"+-" string followed by plus or minus signs only, assuming they are
+not preceded with lines of the same type.  These lines can be
+indented.
+
+A table starting with a vertical bar has "org" type.  Otherwise it
+has "table.el" type.
+
+Org tables end at the first line not starting with a vertical bar.
+Table.el tables end at the first line not starting with either
+a vertical line or a plus sign.  Such lines can be indented.
+
+An org table can only contain table rows.  A table.el table does
+not contain anything.
+
+One or more "#+TBLFM: FORMULAS" lines, where "FORMULAS" can contain
+any character, can follow an org table.
+
+* Elements
+Elements cannot contain any other element.
+
+Only [[#Keywords][keywords]] whose name belongs to
+~org-element-document-properties~, [[#Blocks][verse blocks]] , [[#Paragraphs][paragraphs]] and
+[[#Table_Rows][table rows]] can contain objects.
+
+** Babel Call
+Pattern for babel calls is:
+
+#+BEGIN_EXAMPLE
+,#+CALL: VALUE
+#+END_EXAMPLE
+
+VALUE is optional.  It can contain any character but a new line.
+
+** Blocks
+Like [[#Greater_Blocks][greater blocks]], pattern for blocks is:
+
+#+BEGIN_EXAMPLE
+,#+BEGIN_NAME DATA
+CONTENTS
+,#+END_NAME
+#+END_EXAMPLE
+
+NAME cannot contain any whitespace character.
+
+If NAME is "COMMENT", it will be a "comment block".  If it is
+"EXAMPLE", it will be an "example block".  If it is "EXPORT", it
+will be an "export block".  If it is "SRC", it will be a "source
+block".  If it is "VERSE", it will be a "verse block".
+
+DATA can contain any character but a new line.  It can be ommitted,
+unless the block is either a "source block" or an "export block".
+
+In the latter case, it should be constituted of a single word.
+
+In the former case, it must follow the pattern "LANGUAGE SWITCHES
+ARGUMENTS", where SWITCHES and ARGUMENTS are optional.
+
+LANGUAGE cannot contain any whitespace character.
+
+SWITCHES is made of any number of "SWITCH" patterns, separated by
+blank lines.
+
+A SWITCH pattern is either "-l "FORMAT"", where FORMAT can contain
+any character but a double quote and a new line, "-S" or "+S",
+where S stands for a single letter.
+
+ARGUMENTS can contain any character but a new line.
+
+CONTENTS can contain any character, including new lines.  Though it
+will only contain Org objects if the block is a verse block.
+Otherwise, CONTENTS will not be parsed.
+
+** Clock, Diary Sexp and Planning
+A clock follows the pattern:
+
+#+BEGIN_EXAMPLE
+CLOCK: TIMESTAMP DURATION
+#+END_EXAMPLE
+
+Both TIMESTAMP and DURATION are optional.
+
+TIMESTAMP is a [[#Timestamp][timestamp]] object.
+
+DURATION follows the pattern:
+
+#+BEGIN_EXAMPLE
+=> HH:MM
+#+END_EXAMPLE
+
+HH is a number containing any number of digits.  MM is a two digit
+numbers.
+
+A diary sexp is a line starting at column 0 with "%%(" string.  It
+can then contain any character besides a new line.
+
+A planning is an element with the following pattern:
+
+#+BEGIN_EXAMPLE
+HEADLINE
+PLANNING
+#+END_EXAMPLE
+
+where HEADLINE is a [[#Headlines_and_Sections][headline]] element and PLANNING is a line filled
+with INFO parts, where each of them follows the pattern:
+
+#+BEGIN_EXAMPLE
+KEYWORD: TIMESTAMP
+#+END_EXAMPLE
+
+KEYWORD is either "DEADLINE", "SCHEDULED" or "CLOSED".  TIMESTAMP
+is a [[#Timestamp][timestamp]] object.
+
+In particular, no blank line is allowed between PLANNING and
+HEADLINE.
+
+** Comments
+A "comment line" starts with a hash signe and a whitespace
+character or an end of line.
+
+Comments can contain any number of consecutive comment lines.
+
+** Fixed Width Areas
+A "fixed-width line" start with a colon character and a whitespace
+or an end of line.
+
+Fixed width areas can contain any number of consecutive fixed-width
+lines.
+
+** Horizontal Rules
+A horizontal rule is a line made of at least 5 consecutive hyphens.
+It can be indented.
+
+** Keywords
+Keywords follow the syntax:
+
+#+BEGIN_EXAMPLE
+,#+KEY: VALUE
+#+END_EXAMPLE
+
+KEY can contain any non-whitespace character, but it cannot be
+equal to "CALL" or any affiliated keyword.
+
+VALUE can contain any character excepted a new line.
+
+If KEY belongs to ~org-element-document-properties~, VALUE can
+contain objects.
+
+** LaTeX Environments
+Pattern for LaTeX environments is:
+
+#+BEGIN_EXAMPLE
+\begin{NAME} CONTENTS \end{NAME}
+#+END_EXAMPLE
+
+NAME is constituted of alpha-numeric or asterisk characters.
+
+CONTENTS can contain anything but the "\end{NAME}" string.
+
+** Node Properties
+Node properties can only exist in [[#Property_Drawers][property drawers]].  Their pattern
+is any of the following
+
+#+BEGIN_EXAMPLE
+:NAME: VALUE
+
+:NAME+: VALUE
+
+:NAME:
+
+:NAME+:
+#+END_EXAMPLE
+
+NAME can contain any non-whitespace character but cannot end with
+a plus sign.  It cannot be the empty string.
+
+VALUE can contain anything but a newline character.
+
+** Paragraphs
+Paragraphs are the default element, which means that any
+unrecognized context is a paragraph.
+
+Empty lines and other elements end paragraphs.
+
+Paragraphs can contain every type of object.
+
+** Table Rows
+A table rows is either constituted of a vertical bar and any number
+of [[#Table_Cells][table cells]] or a vertical bar followed by a hyphen.
+
+In the first case the table row has the "standard" type.  In the
+second case, it has the "rule" type.
+
+Table rows can only exist in [[#Tables][tables]].
+
+* Objects
+Objects can only be found in the following locations:
+
+- [[#Affiliated_keywords][affiliated keywords]] defined in ~org-element-parsed-keywords~,
+- [[#Keywords][document properties]],
+- [[#Headlines_and_Sections][headline]] titles,
+- [[#Inlinetasks][inlinetask]] titles,
+- [[#Plain_Lists_and_Items][item]] tags,
+- [[#Paragraphs][paragraphs]],
+- [[#Table_Cells][table cells]],
+- [[#Table_Rows][table rows]], which can only contain table cell
+  objects,
+- [[#Blocks][verse blocks]].
+
+Most objects cannot contain objects.  Those which can will be
+specified.
+
+** Entities and LaTeX Fragments
+An entity follows the pattern:
+
+#+BEGIN_EXAMPLE
+\NAME POST
+#+END_EXAMPLE
+
+where NAME has a valid association in either ~org-entities~ or
+~org-entities-user~.
+
+POST is the end of line, "{}" string, or a non-alphabetical
+character.  It isn't separated from NAME by a whitespace character.
+
+A LaTeX fragment can follow multiple patterns:
+
+#+BEGIN_EXAMPLE
+\NAME BRACKETS
+\(CONTENTS\)
+\[CONTENTS\]
+$$CONTENTS$$
+PRE$CHAR$POST
+PRE$BORDER1 BODY BORDER2$POST
+#+END_EXAMPLE
+
+NAME contains alphabetical characters only and must not have an
+association in either ~org-entities~ or ~org-entities-user~.
+
+BRACKETS is optional, and is not separated from NAME with white
+spaces.  It may contain any number of the following patterns:
+
+#+BEGIN_EXAMPLE
+[CONTENTS1]
+{CONTENTS2}
+#+END_EXAMPLE
+
+where CONTENTS1 can contain any characters excepted "{" "}", "["
+"]" and newline and CONTENTS2 can contain any character excepted
+"{", "}" and newline.
+
+CONTENTS can contain any character but cannot contain "\)" in the
+second template or "\]" in the third one.
+
+PRE is either the beginning of line or a character different from
+~$~.
+
+CHAR is a non-whitespace character different from ~.~, ~,~, ~?~,
+~;~, ~'~ or a double quote.
+
+POST is any punctuation (including parentheses and quotes) or space
+character, or the end of line.
+
+BORDER1 is a non-whitespace character different from ~.~, ~;~, ~.~
+and ~$~.
+
+BODY can contain any character excepted ~$~, and may not span over
+more than 3 lines.
+
+BORDER2 is any non-whitespace character different from ~,~, ~.~ and
+~$~.
+
+-----
+
+#+BEGIN_QUOTE
+It would introduce incompatibilities with previous Org versions,
+but support for ~$...$~ (and for symmetry, ~$$...$$~) constructs
+ought to be removed.
+
+They are slow to parse, fragile, redundant and imply false
+positives.  --- ngz
+#+END_QUOTE
+
+** Export Snippets
+Patter for export snippets is:
+
+#+BEGIN_EXAMPLE
+@@NAME:VALUE@@
+#+END_EXAMPLE
+
+NAME can contain any alpha-numeric character and hyphens.
+
+VALUE can contain anything but "@@" string.
+
+** Footnote References
+There are four patterns for footnote references:
+
+#+BEGIN_EXAMPLE
+[fn:LABEL]
+[fn:LABEL:DEFINITION]
+[fn::DEFINITION]
+#+END_EXAMPLE
+
+LABEL can contain any word constituent character, hyphens and
+underscores.
+
+DEFINITION can contain any character.  Though opening and closing
+square brackets must be balanced in it.  It can contain any object
+encountered in a paragraph, even other footnote references.
+
+If the reference follows the second pattern, it is called an
+"inline footnote".  If it follows the third one, i.e. if LABEL is
+omitted, it is an "anonymous footnote".
+
+** Inline Babel Calls and Source Blocks
+Inline Babel calls follow any of the following patterns:
+
+#+BEGIN_EXAMPLE
+call_NAME(ARGUMENTS)
+call_NAME[HEADER](ARGUMENTS)[HEADER]
+#+END_EXAMPLE
+
+NAME can contain any character besides ~(~, ~)~ and "\n".
+
+HEADER can contain any character besides ~]~ and "\n".
+
+ARGUMENTS can contain any character besides ~)~ and "\n".
+
+Inline source blocks follow any of the following patterns:
+
+#+BEGIN_EXAMPLE
+src_LANG{BODY}
+src_LANG[OPTIONS]{BODY}
+#+END_EXAMPLE
+
+LANG can contain any non-whitespace character.
+
+OPTIONS and BODY can contain any character but "\n".
+
+** Line Breaks
+A line break consists in "\\SPACE" pattern at the end of an
+otherwise non-empty line.
+
+SPACE can contain any number of tabs and spaces, including 0.
+
+** Links
+There are 4 major types of links:
+
+#+BEGIN_EXAMPLE
+PRE1 RADIO POST1          ("radio" link)
+<PROTOCOL:PATH>           ("angle" link)
+PRE2 PROTOCOL:PATH2 POST2 ("plain" link)
+[[PATH3]DESCRIPTION]      ("regular" link)
+#+END_EXAMPLE
+
+PRE1 and POST1, when they exist, are non alphanumeric characters.
+
+RADIO is a string matched by some [[#Targets_and_Radio_Targets][radio target]].  It may contain
+[[#Entities_and_LaTeX_Fragments][entities]], [[#Entities_and_LaTeX_Fragments][latex fragments]], [[#Subscript_and_Superscript][subscript]] and [[#Subscript_and_Superscript][superscript]].
+
+PROTOCOL is a string among ~org-link-types~.
+
+PATH can contain any character but ~]~, ~<~, ~>~ and ~\n~.
+
+PRE2 and POST2, when they exist, are non word constituent
+characters.
+
+PATH2 can contain any non-whitespace character excepted ~(~, ~)~,
+~<~ and ~>~.  It must end with a word-constituent character, or any
+non-whitespace non-punctuation character followed by ~/~.
+
+DESCRIPTION must be enclosed within square brackets.  It can
+contain any character but square brackets.  It can contain any
+object found in a paragraph excepted a [[#Footnote_References][footnote reference]], a [[#Targets_and_Radio_Targets][radio
+target]] and a [[#Line_Breaks][line break]].  It cannot contain another link either,
+unless it is a plain link.
+
+DESCRIPTION is optional.
+
+PATH3 is built according to the following patterns:
+
+#+BEGIN_EXAMPLE
+FILENAME           ("file" type)
+PROTOCOL:PATH4     ("PROTOCOL" type)
+PROTOCOL://PATH4   ("PROTOCOL" type)
+id:ID              ("id" type)
+#CUSTOM-ID         ("custom-id" type)
+(CODEREF)          ("coderef" type)
+FUZZY              ("fuzzy" type)
+#+END_EXAMPLE
+
+FILENAME is a file name, either absolute or relative.
+
+PATH4 can contain any character besides square brackets.
+
+ID is constituted of hexadecimal numbers separated with hyphens.
+
+PATH4, CUSTOM-ID, CODEREF and FUZZY can contain any character
+besides square brackets.
+
+-----
+
+#+BEGIN_QUOTE
+I suggest to remove angle links.  If one needs spaces in PATH, she
+can use standard link syntax instead.
+
+I also suggest to remove ~org-link-types~ dependency in PROTOCOL
+and match ~[a-zA-Z]~ instead, for portability.  --- ngz
+#+END_QUOTE
+
+** Macros
+Macros follow the pattern:
+
+#+BEGIN_EXAMPLE
+{{{NAME(ARGUMENTS)}}}
+#+END_EXAMPLE
+
+NAME must start with a letter and can be followed by any number of
+alpha-numeric characters, hyphens and underscores.
+
+ARGUMENTS can contain anything but "}}}" string.  Values within
+ARGUMENTS are separated by commas.  Non-separating commas have to
+be escaped with a backslash character.
+
+** Targets and Radio Targets
+Radio targets follow the pattern:
+
+#+BEGIN_EXAMPLE
+<<<CONTENTS>>>
+#+END_EXAMPLE
+
+CONTENTS can be any character besides ~<~, ~>~ and "\n".  It cannot
+start or end with a whitespace character.  As far as objects go, it
+can contain [[#Emphasis_Markers][text markup]], [[#Entities_and_LaTeX_Fragments][entities]], [[#Entities_and_LaTeX_Fragments][latex fragments]], [[#Subscript_and_Superscript][subscript]] and
+[[#Subscript_and_Superscript][superscript]] only.
+
+Targets follow the pattern:
+
+#+BEGIN_EXAMPLE
+<<TARGET>>
+#+END_EXAMPLE
+
+TARGET can contain any character besides ~<~, ~>~ and "\n".  It
+cannot start or end with a whitespace character.  It cannot contain
+any object.
+
+** Statistics Cookies
+Statistics cookies follow either pattern:
+
+#+BEGIN_EXAMPLE
+[PERCENT%]
+[NUM1/NUM2]
+#+END_EXAMPLE
+
+PERCENT, NUM1 and NUM2 are numbers or the empty string.
+
+** Subscript and Superscript
+Pattern for subscript is:
+
+#+BEGIN_EXAMPLE
+CHAR_SCRIPT
+#+END_EXAMPLE
+
+Pattern for superscript is:
+
+#+BEGIN_EXAMPLE
+CHAR^SCRIPT
+#+END_EXAMPLE
+
+CHAR is any non-whitespace character.
+
+SCRIPT can be ~*~ or an expression enclosed in parenthesis
+(respectively curly brackets), possibly containing balanced
+parenthesis (respectively curly brackets).
+
+SCRIPT can also follow the pattern:
+
+#+BEGIN_EXAMPLE
+SIGN CHARS FINAL
+#+END_EXAMPLE
+
+SIGN is either a plus sign, a minus sign, or an empty string.
+
+CHARS is any number of alpha-numeric characters, commas,
+backslashes and dots, or an empty string.
+
+FINAL is an alpha-numeric character.
+
+There is no white space between SIGN, CHARS and FINAL.
+
+** Table Cells
+Table cells follow the pattern:
+
+#+BEGIN_EXAMPLE
+CONTENTS SPACES|
+#+END_EXAMPLE
+
+CONTENTS can contain any character excepted a vertical bar.
+
+SPACES contains any number of space characters, including zero.  It
+can be used to align properly the table.
+
+The final bar may be replaced with a newline character for the last
+cell in row.
+
+** Timestamps
+There are seven possible patterns for timestamps:
+
+#+BEGIN_EXAMPLE
+<%%(SEXP)>                                   (diary)
+<DATE TIME REPEATER-OR-DELAY>                                  (active)
+[DATE TIME REPEATER-OR-DELAY]                                  (inactive)
+<DATE TIME REPEATER-OR-DELAY>--<DATE TIME REPEATER-OR-DELAY>   (active range)
+<DATE TIME-TIME REPEATER-OR-DELAY>                             (active range)
+[DATE TIME REPEATER-OR-DELAY]--[DATE TIME REPEATER-OR-DELAY]   (inactive range)
+[DATE TIME-TIME REPEATER-OR-DELAY]                             (inactive range)
+#+END_EXAMPLE
+
+SEXP can contain any character excepted ~>~ and ~\n~.
+
+DATE follows the pattern:
+
+#+BEGIN_EXAMPLE
+YYYY-MM-DD DAYNAME
+#+END_EXAMPLE
+
+Y, M and D are digits.  DAYNAME can contain any non
+whitespace-character besides ~+~, ~-~, ~]~, ~>~, a digit or ~\n~.
+
+TIME follows the pattern =H:MM~.  H can be one or two digit long
+and can start with 0.
+
+REPEATER-OR-DELAY follows the pattern:
+
+#+BEGIN_EXAMPLE
+MARK VALUE UNIT
+#+END_EXAMPLE
+
+MARK is ~+~ (cumulate type), ~++~ (catch-up type) or ~.+~ (restart
+type) for a repeater, and ~-~ (all type) or ~--~ (first type) for
+warning delays.
+
+VALUE is a number.
+
+UNIT is a character among ~h~ (hour), ~d~ (day), ~w~ (week), ~m~
+(month), ~y~ (year).
+
+MARK, VALUE and UNIT are not separated by whitespace characters.
+
+There can be two REPEATER-OR-DELAY in the timestamp: one as
+a repeater and one as a warning delay.
+
+** Text Markup
+Text markup follows the pattern:
+
+#+BEGIN_EXAMPLE
+PRE MARKER CONTENTS MARKER POST
+#+END_EXAMPLE
+
+PRE is a whitespace character, ~(~, ~{~ ~'~ or a double quote.  It
+can also be a beginning of line.
+
+MARKER is a character among ~*~ (bold), ~=~ (verbatim), ~/~
+(italic), ~+~ (strike-through), ~_~ (underline), ~~~ (code).
+
+CONTENTS is a string following the pattern:
+
+#+BEGIN_EXAMPLE
+BORDER BODY BORDER
+#+END_EXAMPLE
+
+BORDER can be any non-whitespace character excepted ~,~, ~'~ or
+a double quote.
+
+BODY can contain contain any character but may not span over more
+than 3 lines.
+
+BORDER and BODY are not separated by whitespaces.
+
+CONTENTS can contain any object encountered in a paragraph when
+markup is "bold", "italic", "strike-through" or "underline".
+
+POST is a whitespace character, ~-~, ~.~, ~,~, ~:~, ~!~, ~?~, ~'~,
+~)~, ~}~ or a double quote.  It can also be an end of line.
+
+PRE, MARKER, CONTENTS, MARKER and POST are not separated by
+whitespace characters.
+
+-----
+
+#+BEGIN_QUOTE
+All of this is wrong if ~org-emphasis-regexp-components~ or
+~org-emphasis-alist~ are modified.
+
+This should really be simplified and made persistent (i.e. no
+defcustom allowed).  Otherwise, portability and parsing are
+jokes.
+
+Also, CONTENTS should be anything within code and verbatim
+emphasis, by definition.  --- ngz
+#+END_QUOTE


### PR DESCRIPTION
This PR adds a copy of [Org Syntax Definition](http://orgmode.org/worg/dev/org-syntax.html) from orgmode.org).

---
- [Headlines and Sections](#sec-1)
- [Affiliated Keywords](#sec-2)
- [Greater Elements](#sec-3)
  - [Greater Blocks](#sec-3-1)
  - [Drawers and Property Drawers](#sec-3-2)
  - [Dynamic Blocks](#sec-3-3)
  - [Footnote Definitions](#sec-3-4)
  - [Inlinetasks](#sec-3-5)
  - [Plain Lists and Items](#sec-3-6)
  - [Property Drawers](#sec-3-7)
  - [Tables](#sec-3-8)
- [Elements](#sec-4)
  - [Babel Call](#sec-4-1)
  - [Blocks](#sec-4-2)
  - [Clock, Diary Sexp and Planning](#sec-4-3)
  - [Comments](#sec-4-4)
  - [Fixed Width Areas](#sec-4-5)
  - [Horizontal Rules](#sec-4-6)
  - [Keywords](#sec-4-7)
  - [LaTeX Environments](#sec-4-8)
  - [Node Properties](#sec-4-9)
  - [Paragraphs](#sec-4-10)
  - [Table Rows](#sec-4-11)
- [Objects](#sec-5)
  - [Entities and LaTeX Fragments](#sec-5-1)
  - [Export Snippets](#sec-5-2)
  - [Footnote References](#sec-5-3)
  - [Inline Babel Calls and Source Blocks](#sec-5-4)
  - [Line Breaks](#sec-5-5)
  - [Links](#sec-5-6)
  - [Macros](#sec-5-7)
  - [Targets and Radio Targets](#sec-5-8)
  - [Statistics Cookies](#sec-5-9)
  - [Subscript and Superscript](#sec-5-10)
  - [Table Cells](#sec-5-11)
  - [Timestamps](#sec-5-12)
  - [Text Markup](#sec-5-13)

This document describes and comments Org syntax as it is currently read by its parser (Org Elements) and, therefore, by the export framework. It also includes a few comments on that syntax.

A core concept in this syntax is that only headlines, sections, planning lines and property drawers are context-free. Every other syntactical part only exists within specific environments.

Three categories are used to classify these environments: &ldquo;Greater elements&rdquo;, &ldquo;elements&rdquo;, and &ldquo;objects&rdquo;, from the broadest scope to the narrowest. The word &ldquo;element&rdquo; is used for both Greater and non-Greater elements, the context should make that clear.

The paragraph is the unit of measurement. An element defines syntactical parts that are at the same level as a paragraph, i.e. which cannot contain or be included in a paragraph. An object is a part that could be included in an element. Greater elements are all parts that can contain an element.

Empty lines belong to the largest element ending before them. For example, in a list, empty lines between items belong are part of the item before them, but empty lines at the end of a list belong to the plain list element.

Unless specified otherwise, case is not significant.
# Headlines and Sections<a id="sec-1" name="sec-1"></a>

A headline is defined as:

```
STARS KEYWORD PRIORITY TITLE TAGS
```

STARS is a string starting at column 0, containing at least one asterisk (and up to `org-inlinetask-min-level` if `org-inlinetask` library is loaded) and ended by a space character. The number of asterisks is used to define the level of the headline. It&rsquo;s the sole compulsory part of a headline.

KEYWORD is a TODO keyword, which has to belong to the list defined in `org-todo-keywords-1`. Case is significant.

PRIORITY is a priority cookie, i.e. a single letter preceded by a hash sign # and enclosed within square brackets.

TITLE can be made of any character but a new line. Though, it will match after every other part have been matched.

TAGS is made of words containing any alpha-numeric character, underscore, at sign, hash sign or percent sign, and separated with colons.

Examples of valid headlines include:

```
*

** DONE

*** Some e-mail

**** TODO [#A] COMMENT Title :tag:a2%:
```

If the first word appearing in the title is &ldquo;COMMENT&rdquo;, the headline will be considered as &ldquo;commented&rdquo;. Case is significant.

If its title is `org-footnote-section`, it will be considered as a &ldquo;footnote section&rdquo;. Case is significant.

If &ldquo;ARCHIVE&rdquo; is one of its tags, it will be considered as &ldquo;archived&rdquo;. Case is significant.

A headline contains directly one section (optionally), followed by any number of deeper level headlines.

A section contains directly any greater element or element. Only a headline can contain a section. As an exception, text before the first headline in the document also belongs to a section.

As an example, consider the following document:

``` org
An introduction.

* A Headline 

  Some text.

** Sub-Topic 1

** Sub-Topic 2

*** Additional entry
```

Its internal structure could be summarized as:

```
(document
 (section)
 (headline
  (section)
  (headline)
  (headline
   (headline))))
```
# Affiliated Keywords<a id="sec-2" name="sec-2"></a>

With the exception of inlinetasks (See section ), items (See section ), planning (See section ), clocks (See section ), node properties (See section ) and table rows (See section ), every other element type can be assigned attributes.

This is done by adding specific keywords, named &ldquo;affiliated keywords&rdquo;, just above the element considered, no blank line allowed.

Affiliated keywords are built upon one of the following patterns: &ldquo;#+KEY: VALUE&rdquo;, &ldquo;#+KEY[OPTIONAL]: VALUE&rdquo; or &ldquo;#+ATTR<sub>BACKEND</sub>: VALUE&rdquo;.

KEY is either &ldquo;CAPTION&rdquo;, &ldquo;HEADER&rdquo;, &ldquo;NAME&rdquo;, &ldquo;PLOT&rdquo; or &ldquo;RESULTS&rdquo; string.

BACKEND is a string constituted of alpha-numeric characters, hyphens or underscores.

OPTIONAL and VALUE can contain any character but a new line. Only &ldquo;CAPTION&rdquo; and &ldquo;RESULTS&rdquo; keywords can have an optional value.

An affiliated keyword can appear more than once if KEY is either &ldquo;CAPTION&rdquo; or &ldquo;HEADER&rdquo; or if its pattern is &ldquo;#+ATTR<sub>BACKEND</sub>: VALUE&rdquo;.

&ldquo;CAPTION&rdquo;, &ldquo;AUTHOR&rdquo;, &ldquo;DATE&rdquo; and &ldquo;TITLE&rdquo; keywords can contain objects in their value and their optional value, if applicable.
# Greater Elements<a id="sec-3" name="sec-3"></a>

Unless specified otherwise, greater elements can contain directly any other element or greater element excepted:
-   elements of their own type,
-   node properties (See section ), which can only be found in property drawers (See section ),
-   items (See section ), which can only be found in plain lists (See section ).
## Greater Blocks<a id="sec-3-1" name="sec-3-1"></a>

Greater blocks consist in the following pattern:

```
#+BEGIN_NAME PARAMETERS
CONTENTS
#+END_NAME
```

NAME can contain any non-whitespace character.

PARAMETERS can contain any character other than new line, and can be omitted.

If NAME is &ldquo;CENTER&rdquo;, it will be a &ldquo;center block&rdquo;. If it is &ldquo;QUOTE&rdquo;, it will be a &ldquo;quote block&rdquo;.

If the block is neither a center block, a quote block or a block element (See section ), it will be a &ldquo;special block&rdquo;.

CONTENTS can contain any element, except : a line `#+END_NAME` on its own. Also lines beginning with STARS must be quoted by a comma.
## Drawers and Property Drawers<a id="sec-3-2" name="sec-3-2"></a>

Pattern for drawers is:

```
:NAME:
CONTENTS
:END:
```

NAME can contain word-constituent characters, hyphens and underscores.

CONTENTS can contain any element but another drawer.
## Dynamic Blocks<a id="sec-3-3" name="sec-3-3"></a>

Pattern for dynamic blocks is:

```
#+BEGIN: NAME PARAMETERS
CONTENTS
#+END:
```

NAME cannot contain any whitespace character.

PARAMETERS can contain any character and can be omitted.
## Footnote Definitions<a id="sec-3-4" name="sec-3-4"></a>

Pattern for footnote definitions is:

```
[fn:LABEL] CONTENTS
```

It must start at column 0.

LABEL is either a number or follows the pattern &ldquo;fn:WORD&rdquo;, where word can contain any word-constituent character, hyphens and underscore characters.

CONTENTS can contain any element excepted another footnote definition. It ends at the next footnote definition, the next headline, two consecutive empty lines or the end of buffer.
## Inlinetasks<a id="sec-3-5" name="sec-3-5"></a>

Inlinetasks are defined by `org-inlinetask-min-level` contiguous asterisk characters starting at column 0, followed by a whitespace character.

Optionally, inlinetasks can be ended with a string constituted of `org-inlinetask-min-level` contiguous asterisk characters starting at column 0, followed by a space and the &ldquo;END&rdquo; string.

Inlinetasks are recognized only after `org-inlinetask` library is loaded.
## Plain Lists and Items<a id="sec-3-6" name="sec-3-6"></a>

Items are defined by a line starting with the following pattern: &ldquo;BULLET COUNTER-SET CHECK-BOX TAG&rdquo;, in which only BULLET is mandatory.

BULLET is either an asterisk, a hyphen, a plus sign character or follows either the pattern &ldquo;COUNTER.&rdquo; or &ldquo;COUNTER)". In any case, BULLET is follwed by a whitespace character or line ending.

COUNTER can be a number or a single letter.

COUNTER-SET follows the pattern [@COUNTER].

CHECK-BOX is either a single whitespace character, a &ldquo;X&rdquo; character or a hyphen, enclosed within square brackets.

TAG follows &ldquo;TAG-TEXT ::&rdquo; pattern, where TAG-TEXT can contain any character but a new line.

An item ends before the next item, the first line less or equally indented than its starting line, or two consecutive empty lines. Indentation of lines within other greater elements do not count, neither do inlinetasks boundaries.

A plain list is a set of consecutive items of the same indentation. It can only directly contain items.

If first item in a plain list has a counter in its bullet, the plain list will be an &ldquo;ordered plain-list&rdquo;. If it contains a tag, it will be a &ldquo;descriptive list&rdquo;. Otherwise, it will be an &ldquo;unordered list&rdquo;. List types are mutually exclusive.

For example, consider the following excerpt of an Org document:

```
1. item 1
2. [X] item 2
   - some tag :: item 2.1
```

Its internal structure is as follows:

```
(ordered-plain-list
 (item)
 (item
  (descriptive-plain-list
   (item))))
```
## Property Drawers<a id="sec-3-7" name="sec-3-7"></a>

Property drawers are a special type of drawer containing properties attached to a headline. They are located right after a headline (See section ) and its planning (See section ) information.

```
HEADLINE
PROPERTYDRAWER

HEADLINE
PLANNING
PROPERTYDRAWER
```

PROPERTYDRAWER follows the pattern

```
:PROPERTIES:
CONTENTS
:END:
```

where CONTENTS consists of zero or more node properties (See section ).
## Tables<a id="sec-3-8" name="sec-3-8"></a>

Tables start at lines beginning with either a vertical bar or the &ldquo;+-&rdquo; string followed by plus or minus signs only, assuming they are not preceded with lines of the same type. These lines can be indented.

A table starting with a vertical bar has &ldquo;org&rdquo; type. Otherwise it has &ldquo;table.el&rdquo; type.

Org tables end at the first line not starting with a vertical bar. Table.el tables end at the first line not starting with either a vertical line or a plus sign. Such lines can be indented.

An org table can only contain table rows. A table.el table does not contain anything.

One or more &ldquo;#+TBLFM: FORMULAS&rdquo; lines, where &ldquo;FORMULAS&rdquo; can contain any character, can follow an org table.
# Elements<a id="sec-4" name="sec-4"></a>

Elements cannot contain any other element.

Only keywords (See section ) whose name belongs to `org-element-document-properties`, verse blocks (See section ) , paragraphs (See section ) and table rows (See section ) can contain objects.
## Babel Call<a id="sec-4-1" name="sec-4-1"></a>

Pattern for babel calls is:

```
#+CALL: VALUE
```

VALUE is optional. It can contain any character but a new line.
## Blocks<a id="sec-4-2" name="sec-4-2"></a>

Like greater blocks (See section ), pattern for blocks is:

```
#+BEGIN_NAME DATA
CONTENTS
#+END_NAME
```

NAME cannot contain any whitespace character.

If NAME is &ldquo;COMMENT&rdquo;, it will be a &ldquo;comment block&rdquo;. If it is &ldquo;EXAMPLE&rdquo;, it will be an &ldquo;example block&rdquo;. If it is &ldquo;EXPORT&rdquo;, it will be an &ldquo;export block&rdquo;. If it is &ldquo;SRC&rdquo;, it will be a &ldquo;source block&rdquo;. If it is &ldquo;VERSE&rdquo;, it will be a &ldquo;verse block&rdquo;.

DATA can contain any character but a new line. It can be ommitted, unless the block is either a &ldquo;source block&rdquo; or an &ldquo;export block&rdquo;.

In the latter case, it should be constituted of a single word.

In the former case, it must follow the pattern &ldquo;LANGUAGE SWITCHES ARGUMENTS&rdquo;, where SWITCHES and ARGUMENTS are optional.

LANGUAGE cannot contain any whitespace character.

SWITCHES is made of any number of &ldquo;SWITCH&rdquo; patterns, separated by blank lines.

A SWITCH pattern is either &ldquo;-l &ldquo;FORMAT"", where FORMAT can contain any character but a double quote and a new line, &ldquo;-S&rdquo; or &ldquo;+S&rdquo;, where S stands for a single letter.

ARGUMENTS can contain any character but a new line.

CONTENTS can contain any character, including new lines. Though it will only contain Org objects if the block is a verse block. Otherwise, CONTENTS will not be parsed.
## Clock, Diary Sexp and Planning<a id="sec-4-3" name="sec-4-3"></a>

A clock follows the pattern:

```
CLOCK: TIMESTAMP DURATION
```

Both TIMESTAMP and DURATION are optional.

TIMESTAMP is a timestamp (See section ) object.

DURATION follows the pattern:

```
=> HH:MM
```

HH is a number containing any number of digits. MM is a two digit numbers.

A diary sexp is a line starting at column 0 with &ldquo;%%(" string. It can then contain any character besides a new line.

A planning is an element with the following pattern:

```
HEADLINE
PLANNING
```

where HEADLINE is a headline (See section ) element and PLANNING is a line filled with INFO parts, where each of them follows the pattern:

```
KEYWORD: TIMESTAMP
```

KEYWORD is either &ldquo;DEADLINE&rdquo;, &ldquo;SCHEDULED&rdquo; or &ldquo;CLOSED&rdquo;. TIMESTAMP is a timestamp (See section ) object.

In particular, no blank line is allowed between PLANNING and HEADLINE.
## Comments<a id="sec-4-4" name="sec-4-4"></a>

A &ldquo;comment line&rdquo; starts with a hash signe and a whitespace character or an end of line.

Comments can contain any number of consecutive comment lines.
## Fixed Width Areas<a id="sec-4-5" name="sec-4-5"></a>

A &ldquo;fixed-width line&rdquo; start with a colon character and a whitespace or an end of line.

Fixed width areas can contain any number of consecutive fixed-width lines.
## Horizontal Rules<a id="sec-4-6" name="sec-4-6"></a>

A horizontal rule is a line made of at least 5 consecutive hyphens. It can be indented.
## Keywords<a id="sec-4-7" name="sec-4-7"></a>

Keywords follow the syntax:

```
#+KEY: VALUE
```

KEY can contain any non-whitespace character, but it cannot be equal to &ldquo;CALL&rdquo; or any affiliated keyword.

VALUE can contain any character excepted a new line.

If KEY belongs to `org-element-document-properties`, VALUE can contain objects.
## LaTeX Environments<a id="sec-4-8" name="sec-4-8"></a>

Pattern for LaTeX environments is:

```
\begin{NAME} CONTENTS \end{NAME}
```

NAME is constituted of alpha-numeric or asterisk characters.

CONTENTS can contain anything but the &ldquo;\end{NAME}&rdquo; string.
## Node Properties<a id="sec-4-9" name="sec-4-9"></a>

Node properties can only exist in property drawers (See section ). Their pattern is any of the following

```
:NAME: VALUE

:NAME+: VALUE

:NAME:

:NAME+:
```

NAME can contain any non-whitespace character but cannot end with a plus sign. It cannot be the empty string.

VALUE can contain anything but a newline character.
## Paragraphs<a id="sec-4-10" name="sec-4-10"></a>

Paragraphs are the default element, which means that any unrecognized context is a paragraph.

Empty lines and other elements end paragraphs.

Paragraphs can contain every type of object.
## Table Rows<a id="sec-4-11" name="sec-4-11"></a>

A table rows is either constituted of a vertical bar and any number of table cells (See section ) or a vertical bar followed by a hyphen.

In the first case the table row has the &ldquo;standard&rdquo; type. In the second case, it has the &ldquo;rule&rdquo; type.

Table rows can only exist in tables (See section ).
# Objects<a id="sec-5" name="sec-5"></a>

Objects can only be found in the following locations:
-   affiliated keywords (See section ) defined in `org-element-parsed-keywords`,
-   document properties (See section ),
-   headline (See section ) titles,
-   inlinetask (See section ) titles,
-   item (See section ) tags,
-   paragraphs (See section ),
-   table cells (See section ),
-   table rows (See section ), which can only contain table cell objects,
-   verse blocks (See section ).

Most objects cannot contain objects. Those which can will be specified.
## Entities and LaTeX Fragments<a id="sec-5-1" name="sec-5-1"></a>

An entity follows the pattern:

```
\NAME POST
```

where NAME has a valid association in either `org-entities` or `org-entities-user`.

POST is the end of line, "{}" string, or a non-alphabetical character. It isn&rsquo;t separated from NAME by a whitespace character.

A LaTeX fragment can follow multiple patterns:

```
\NAME BRACKETS
\(CONTENTS\)
\[CONTENTS\]
$$CONTENTS$$
PRE$CHAR$POST
PRE$BORDER1 BODY BORDER2$POST
```

NAME contains alphabetical characters only and must not have an association in either `org-entities` or `org-entities-user`.

BRACKETS is optional, and is not separated from NAME with white spaces. It may contain any number of the following patterns:

```
[CONTENTS1]
{CONTENTS2}
```

where CONTENTS1 can contain any characters excepted "{" "}", "[" "]" and newline and CONTENTS2 can contain any character excepted "{&ldquo;, "}" and newline.

CONTENTS can contain any character but cannot contain &ldquo;\)" in the second template or &ldquo;\]" in the third one.

PRE is either the beginning of line or a character different from `$`.

CHAR is a non-whitespace character different from `.`, ~,~, `?`, `;`, ~&rsquo;~ or a double quote.

POST is any punctuation (including parentheses and quotes) or space character, or the end of line.

BORDER1 is a non-whitespace character different from `.`, `;`, `.` and `$`.

BODY can contain any character excepted `$`, and may not span over more than 3 lines.

BORDER2 is any non-whitespace character different from ~,~, `.` and `$`.

---

> It would introduce incompatibilities with previous Org versions, but support for `$...$` (and for symmetry, `$$...$$`) constructs ought to be removed.
> 
> They are slow to parse, fragile, redundant and imply false positives. &#x2014; ngz
## Export Snippets<a id="sec-5-2" name="sec-5-2"></a>

Patter for export snippets is:

```
@@NAME:VALUE@@
```

NAME can contain any alpha-numeric character and hyphens.

VALUE can contain anything but &ldquo;@@&rdquo; string.
## Footnote References<a id="sec-5-3" name="sec-5-3"></a>

There are four patterns for footnote references:

```
[fn:LABEL]
[fn:LABEL:DEFINITION]
[fn::DEFINITION]
```

LABEL can contain any word constituent character, hyphens and underscores.

DEFINITION can contain any character. Though opening and closing square brackets must be balanced in it. It can contain any object encountered in a paragraph, even other footnote references.

If the reference follows the second pattern, it is called an &ldquo;inline footnote&rdquo;. If it follows the third one, i.e. if LABEL is omitted, it is an &ldquo;anonymous footnote&rdquo;.
## Inline Babel Calls and Source Blocks<a id="sec-5-4" name="sec-5-4"></a>

Inline Babel calls follow any of the following patterns:

```
call_NAME(ARGUMENTS)
call_NAME[HEADER](ARGUMENTS)[HEADER]
```

NAME can contain any character besides `(`, `)` and &ldquo;\n&rdquo;.

HEADER can contain any character besides `]` and &ldquo;\n&rdquo;.

ARGUMENTS can contain any character besides `)` and &ldquo;\n&rdquo;.

Inline source blocks follow any of the following patterns:

```
src_LANG{BODY}
src_LANG[OPTIONS]{BODY}
```

LANG can contain any non-whitespace character.

OPTIONS and BODY can contain any character but &ldquo;\n&rdquo;.
## Line Breaks<a id="sec-5-5" name="sec-5-5"></a>

A line break consists in &ldquo;\\SPACE&rdquo; pattern at the end of an otherwise non-empty line.

SPACE can contain any number of tabs and spaces, including 0.
## Links<a id="sec-5-6" name="sec-5-6"></a>

There are 4 major types of links:

```
PRE1 RADIO POST1          ("radio" link)
<PROTOCOL:PATH>           ("angle" link)
PRE2 PROTOCOL:PATH2 POST2 ("plain" link)
[[PATH3]DESCRIPTION]      ("regular" link)
```

PRE1 and POST1, when they exist, are non alphanumeric characters.

RADIO is a string matched by some radio target (See section ). It may contain entities (See section ), latex fragments (See section ), subscript (See section ) and superscript (See section ).

PROTOCOL is a string among `org-link-types`.

PATH can contain any character but `]`, `<`, `>` and `\n`.

PRE2 and POST2, when they exist, are non word constituent characters.

PATH2 can contain any non-whitespace character excepted `(`, `)`, `<` and `>`. It must end with a word-constituent character, or any non-whitespace non-punctuation character followed by `/`.

DESCRIPTION must be enclosed within square brackets. It can contain any character but square brackets. It can contain any object found in a paragraph excepted a footnote reference (See section ), a radio target (See section ) and a line break (See section ). It cannot contain another link either, unless it is a plain link.

DESCRIPTION is optional.

PATH3 is built according to the following patterns:

```
FILENAME           ("file" type)
PROTOCOL:PATH4     ("PROTOCOL" type)
PROTOCOL://PATH4   ("PROTOCOL" type)
id:ID              ("id" type)
#CUSTOM-ID         ("custom-id" type)
(CODEREF)          ("coderef" type)
FUZZY              ("fuzzy" type)
```

FILENAME is a file name, either absolute or relative.

PATH4 can contain any character besides square brackets.

ID is constituted of hexadecimal numbers separated with hyphens.

PATH4, CUSTOM-ID, CODEREF and FUZZY can contain any character besides square brackets.

---

> I suggest to remove angle links. If one needs spaces in PATH, she can use standard link syntax instead.
> 
> I also suggest to remove `org-link-types` dependency in PROTOCOL and match `[a-zA-Z]` instead, for portability. &#x2014; ngz
## Macros<a id="sec-5-7" name="sec-5-7"></a>

Macros follow the pattern:

```
{{{NAME(ARGUMENTS)}}}
```

NAME must start with a letter and can be followed by any number of alpha-numeric characters, hyphens and underscores.

ARGUMENTS can contain anything but "}}}" string. Values within ARGUMENTS are separated by commas. Non-separating commas have to be escaped with a backslash character.
## Targets and Radio Targets<a id="sec-5-8" name="sec-5-8"></a>

Radio targets follow the pattern:

```
<<<CONTENTS>>>
```

CONTENTS can be any character besides `<`, `>` and &ldquo;\n&rdquo;. It cannot start or end with a whitespace character. As far as objects go, it can contain text markup (See section ), entities (See section ), latex fragments (See section ), subscript (See section ) and superscript (See section ) only.

Targets follow the pattern:

```
<<TARGET>>
```

TARGET can contain any character besides `<`, `>` and &ldquo;\n&rdquo;. It cannot start or end with a whitespace character. It cannot contain any object.
## Statistics Cookies<a id="sec-5-9" name="sec-5-9"></a>

Statistics cookies follow either pattern:

```
[PERCENT%]
[NUM1/NUM2]
```

PERCENT, NUM1 and NUM2 are numbers or the empty string.
## Subscript and Superscript<a id="sec-5-10" name="sec-5-10"></a>

Pattern for subscript is:

```
CHAR_SCRIPT
```

Pattern for superscript is:

```
CHAR^SCRIPT
```

CHAR is any non-whitespace character.

SCRIPT can be `*` or an expression enclosed in parenthesis (respectively curly brackets), possibly containing balanced parenthesis (respectively curly brackets).

SCRIPT can also follow the pattern:

```
SIGN CHARS FINAL
```

SIGN is either a plus sign, a minus sign, or an empty string.

CHARS is any number of alpha-numeric characters, commas, backslashes and dots, or an empty string.

FINAL is an alpha-numeric character.

There is no white space between SIGN, CHARS and FINAL.
## Table Cells<a id="sec-5-11" name="sec-5-11"></a>

Table cells follow the pattern:

```
CONTENTS SPACES|
```

CONTENTS can contain any character excepted a vertical bar.

SPACES contains any number of space characters, including zero. It can be used to align properly the table.

The final bar may be replaced with a newline character for the last cell in row.
## Timestamps<a id="sec-5-12" name="sec-5-12"></a>

There are seven possible patterns for timestamps:

```
<%%(SEXP)>                                   (diary)
<DATE TIME REPEATER-OR-DELAY>                                  (active)
[DATE TIME REPEATER-OR-DELAY]                                  (inactive)
<DATE TIME REPEATER-OR-DELAY>--<DATE TIME REPEATER-OR-DELAY>   (active range)
<DATE TIME-TIME REPEATER-OR-DELAY>                             (active range)
[DATE TIME REPEATER-OR-DELAY]--[DATE TIME REPEATER-OR-DELAY]   (inactive range)
[DATE TIME-TIME REPEATER-OR-DELAY]                             (inactive range)
```

SEXP can contain any character excepted `>` and `\n`.

DATE follows the pattern:

```
YYYY-MM-DD DAYNAME
```

Y, M and D are digits. DAYNAME can contain any non whitespace-character besides `+`, `-`, `]`, `>`, a digit or `\n`.

TIME follows the pattern =H:MM~. H can be one or two digit long and can start with 0.

REPEATER-OR-DELAY follows the pattern:

```
MARK VALUE UNIT
```

MARK is `+` (cumulate type), `++` (catch-up type) or `.+` (restart type) for a repeater, and `-` (all type) or `--` (first type) for warning delays.

VALUE is a number.

UNIT is a character among `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year).

MARK, VALUE and UNIT are not separated by whitespace characters.

There can be two REPEATER-OR-DELAY in the timestamp: one as a repeater and one as a warning delay.
## Text Markup<a id="sec-5-13" name="sec-5-13"></a>

Text markup follows the pattern:

```
PRE MARKER CONTENTS MARKER POST
```

PRE is a whitespace character, `(`, `{` ~&rsquo;~ or a double quote. It can also be a beginning of line.

MARKER is a character among `*` (bold), `=` (verbatim), `/` (italic), `+` (strike-through), `_` (underline), `~` (code).

CONTENTS is a string following the pattern:

```
BORDER BODY BORDER
```

BORDER can be any non-whitespace character excepted ~,~, ~&rsquo;~ or a double quote.

BODY can contain contain any character but may not span over more than 3 lines.

BORDER and BODY are not separated by whitespaces.

CONTENTS can contain any object encountered in a paragraph when markup is &ldquo;bold&rdquo;, &ldquo;italic&rdquo;, &ldquo;strike-through&rdquo; or &ldquo;underline&rdquo;.

POST is a whitespace character, `-`, `.`, ~,~, `:`, `!`, `?`, ~&rsquo;~, `)`, `}` or a double quote. It can also be an end of line.

PRE, MARKER, CONTENTS, MARKER and POST are not separated by whitespace characters.

---

> All of this is wrong if `org-emphasis-regexp-components` or `org-emphasis-alist` are modified.
> 
> This should really be simplified and made persistent (i.e. no defcustom allowed). Otherwise, portability and parsing are jokes.
> 
> Also, CONTENTS should be anything within code and verbatim emphasis, by definition. &#x2014; ngz
